### PR TITLE
Update firefox plugin id

### DIFF
--- a/manifest.firefox.json
+++ b/manifest.firefox.json
@@ -26,7 +26,7 @@
   },
   "browser_specific_settings": {
     "gecko": {
-        "id": "{c671b75e-f319-47f5-b230-49e0d8ef7c5e}"
+        "id": "{17a15a43-7d2b-4796-b9a9-1901da7f6335}"
     }
   },
   "manifest_version": 3


### PR DESCRIPTION
I had used the previous id when testing the plugin on the app store and
now it is not letting me upload it again :S had to create a new id.
