### PR TITLE
Clear item when visiting different page

### DIFF
--- a/background.js
+++ b/background.js
@@ -45,8 +45,13 @@ export async function handleTabVisit(actions, tabId, tabUrl) {
     }
     return;
   }
-  // Reaching this line means everything is ok
-  return browserAPI.setIcon({
+  
+  return  showOk(tabId);
+}
+
+async function showOk(tabId) {
+  await browserAPI.cacheSet({boycottZItem: null})
+  browserAPI.setIcon({
     tabId,
     path: {
       128: `/icons/green-triangle-128.png`,


### PR DESCRIPTION
Notced that the banner warning remains after visiting a page that had a boycott item. Removed the item to clear the previous boycott match.
