### PR TITLE
Fix false positive in firefox

### DIFF
--- a/background.js
+++ b/background.js
@@ -20,6 +20,12 @@ const excludedWebsites = [
 export async function handleTabVisit(actions, tabId, tabUrl) {
   browserAPI = actions;
   const urlObject = new URL(tabUrl);
+
+  // ignore urls for local files, firefox about:config and so on..
+  if(!urlObject.hostname) {
+      return;
+  }
+
   const domainName = urlObject.hostname.startsWith("www.")
     ? urlObject.hostname.slice(4)
     : urlObject.hostname;

--- a/manifest.chrome.json
+++ b/manifest.chrome.json
@@ -1,6 +1,6 @@
 {
   "name": "Boycott-Z",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "",
   "permissions": ["tabs", "activeTab", "scripting", "storage"],
   "host_permissions": ["<all_urls>"],

--- a/manifest.firefox.json
+++ b/manifest.firefox.json
@@ -1,6 +1,6 @@
 {
   "name": "Boycott-Z",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "",
   "permissions": ["tabs", "activeTab", "scripting", "storage"],
   "host_permissions": ["<all_urls>"],


### PR DESCRIPTION
Noticed an issue in firefox where there were falso positives when viewing some firefox pages. Turns out it is because the hostname is empty, so when we do the search we were getting the json result for dell
