### PR TITLE
Set width to fix display in firefox

### DIFF
--- a/manifest.chrome.json
+++ b/manifest.chrome.json
@@ -1,6 +1,6 @@
 {
   "name": "Boycott-Z",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "",
   "permissions": ["tabs", "activeTab", "scripting", "storage"],
   "host_permissions": ["<all_urls>"],

--- a/manifest.firefox.json
+++ b/manifest.firefox.json
@@ -1,6 +1,6 @@
 {
   "name": "Boycott-Z",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "",
   "permissions": ["tabs", "activeTab", "scripting", "storage"],
   "host_permissions": ["<all_urls>"],

--- a/popup/popup.css
+++ b/popup/popup.css
@@ -1,7 +1,4 @@
 body {
-  /* margin-top: 25px;
-  margin-bottom: 25px; */
-  min-width: 500px;
 }
 
 /* <i class="fa-solid fa-arrow-up-right-from-square"></i> */
@@ -13,8 +10,8 @@ body {
   /* width: 500px; */
   /* height: 280px; */
   /* height: 350px; */
-  height: auto;
-  min-height: 280px;
+  width: 500px;
+  height: 296px;
   background-repeat: no-repeat;
   background-size: auto 100%;
   /* background-size: cover; */


### PR DESCRIPTION
The width wasn't being set to any value, checked what size should be and set heigh and idth to match the image background.

Tested the overflow by adding bunch of text to the content manualy and the scroll bar appears.
