### PR TITLE
Fix firefox host permissions

### DIFF
--- a/browsers-adapters/firefox/worker-actions.js
+++ b/browsers-adapters/firefox/worker-actions.js
@@ -1,0 +1,15 @@
+export function sendMessageToTab(tabId, msgObj) {
+  return browser.tabs.sendMessage(tabId, msgObj);
+}
+
+export function setIcon(details) {
+  return browser.browserAction.setIcon(details);
+}
+
+export function executeScript(injection) {
+  return browser.scripting.executeScript(injection);
+}
+
+export function cacheSet(keyValuesObj) {
+  return browser.storage.local.set(keyValuesObj);
+}

--- a/browsers-adapters/firefox/worker-listeners.js
+++ b/browsers-adapters/firefox/worker-listeners.js
@@ -1,0 +1,18 @@
+import { handleTabVisit } from "../../background.js";
+import * as actions from "./worker-actions.js";
+
+// Listen when user switches to a tab (activates it)
+browser.tabs.onActivated.addListener((activeInfo) => {
+  browser.tabs.get(activeInfo.tabId, (tab) => {
+    if (tab && tab.url) {
+      handleTabVisit(actions, activeInfo.tabId, tab.url);
+    }
+  });
+});
+
+// Listen for tab updates (when the URL changes)
+browser.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
+  if (tabId && changeInfo.status === "complete") {
+    handleTabVisit(actions, tabId, tab.url);
+  }
+});

--- a/manifest.chrome.json
+++ b/manifest.chrome.json
@@ -1,7 +1,7 @@
 {
   "name": "Boycott-Z",
-  "version": "0.2.1",
-  "description": "",
+  "version": "0.2.2",
+  "description": "Adds a browser add-on icon that turns red when viewed site or product is on the boycott list.",
   "permissions": [
     "tabs",
     "activeTab",

--- a/manifest.firefox.json
+++ b/manifest.firefox.json
@@ -1,25 +1,21 @@
 {
   "name": "Boycott-Z",
   "version": "0.2.1",
-  "description": "",
+  "description": "Adds a browser add-on icon that turns red when viewed site or product is on the boycott list.",
   "permissions": [
+    "<all_urls>",
     "tabs",
     "activeTab",
     "scripting",
     "storage"
   ],
-  "host_permissions": [
-    "<all_urls>"
-  ],
+  "icons": {
+      "48": "icons/green-triangle-128.png"
+  },
   "web_accessible_resources": [
-    {
-      "resources": [],
-      "matches": [
-        "<all_urls>"
-      ]
-    }
+      "popup/*.*"
   ],
-  "action": {
+  "browser_action": {
     "default_icon": {
       "16": "icons/green-triangle-128.png",
       "48": "icons/green-triangle-128.png",
@@ -30,7 +26,7 @@
   },
   "background": {
     "scripts": [
-      "browsers-adapters/chrome/worker-listeners.js"
+      "browsers-adapters/firefox/worker-listeners.js"
     ],
     "type": "module"
   },
@@ -39,5 +35,5 @@
       "id": "{17a15a43-7d2b-4796-b9a9-1901da7f6335}"
     }
   },
-  "manifest_version": 3
+  "manifest_version": 2
 }

--- a/manifest.firefox.json
+++ b/manifest.firefox.json
@@ -1,6 +1,6 @@
 {
   "name": "Boycott-Z",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Adds a browser add-on icon that turns red when viewed site or product is on the boycott list.",
   "permissions": [
     "<all_urls>",

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -1,6 +1,10 @@
 // popup.js
 
-chrome.storage.local.get(["boycottZItem"]).then((result) => {
+if (!('browser' in self)) {
+  self.browser = self.chrome;
+}
+
+browser.storage.local.get(["boycottZItem"]).then((result) => {
   const boycottZItem = result.boycottZItem
   if (!boycottZItem) {
     return window.close()
@@ -44,11 +48,9 @@ chrome.storage.local.get(["boycottZItem"]).then((result) => {
   if (proof) {
     document.getElementById("boycottZProof").addEventListener('click', (event) => {
       let ur = event.target.getAttribute('href')
-      chrome.tabs.create({ url: ur });
+      browser.tabs.create({ url: ur });
+      return false;
     })
-    // $('body').on('click', 'a', function(){
-    //   return false;
-    // });
   }
 
 });


### PR DESCRIPTION
This required changing to MV2 as doing it with MV3 would require a
landing page and extra requests for permissions.

Added firefox specific listeners as the APIs differs between
browser.action.setIcon in chrome and browser.browserAction.setIcon in
firefox